### PR TITLE
Save session Feature

### DIFF
--- a/docassemble/GithubFeedbackForm/data/questions/browse_feedback_sessions.yml
+++ b/docassemble/GithubFeedbackForm/data/questions/browse_feedback_sessions.yml
@@ -1,0 +1,50 @@
+modules:
+  - .github_issue
+---
+objects:
+  - red: DARedis
+---
+mandatory: True
+code: |
+  feedback_guid
+  tmp_screen
+  open_session
+---
+question: tmp_screen
+continue button field: tmp_screen
+
+---
+metadata:
+  title: Browse Feedback Sessions
+  short title: Browse Feedback
+  temporary session: True
+  required privileges:
+    - admin
+---
+if: guids
+id: main browse screen
+question: |
+  Select a feedback session to browse
+fields:
+  - Feedback GUID: feedback_guid
+    datatype: dropdown
+    choices:
+      code: |
+        guids
+continue button label: Open Session
+---
+if: not guids
+question: |
+  No feedback sessions to view
+event: feedback_guid
+---
+code: |
+  guid_map = red.get_data(redis_feedback_key) or {}
+---
+code: |
+  guids = {guid: (info['html_url'] if 'html_url' in info else info.get('session_id') ) for guid, info in guid_map.items()}
+---
+event: open_session
+code: |
+  info = guid_map[feedback_guid]
+  response(url=interview_url(i=info['interview'], session=info['session_id'], temporary=1))

--- a/docassemble/GithubFeedbackForm/data/questions/browse_feedback_sessions.yml
+++ b/docassemble/GithubFeedbackForm/data/questions/browse_feedback_sessions.yml
@@ -7,12 +7,21 @@ objects:
 mandatory: True
 code: |
   feedback_guid
-  tmp_screen
-  open_session
+  feedback_info
 ---
-question: tmp_screen
-continue button field: tmp_screen
+event: feedback_info
+question: Feedback Info
+subquestion: |
+  ## Body
+  ${ guid_map[feedback_guid].get('body') }
 
+  ## Github URL
+  ${ guid_map[feedback_guid].get('html_url') }
+
+  ## Session ID
+  ${ guid_map[feedback_guid].get('interview', '')}:${ guid_map[feedback_guid].get('session_id', '')}
+
+  ${ action_button_html(url_action('open_session'), label='Open Session', color='secondary') }
 ---
 metadata:
   title: Browse Feedback Sessions
@@ -31,7 +40,6 @@ fields:
     choices:
       code: |
         guids
-continue button label: Open Session
 ---
 if: not guids
 question: |

--- a/docassemble/GithubFeedbackForm/data/questions/feedback.yml
+++ b/docassemble/GithubFeedbackForm/data/questions/feedback.yml
@@ -24,7 +24,7 @@ code: |
   elif reason == 'help':
     gentle_exit
   else:
-    value(reason)  
+    value(reason)
     issue_template = generic_report[reason]
   send_to_github
   prevent_going_back()
@@ -72,6 +72,8 @@ code: question_id = url_args.get('question_id')
 code: package_version = url_args.get('package_version')
 ---
 code: filename = url_args.get('filename')
+---
+code: orig_session_id = url_args.get('session_id')
 ---
 id: intro
 question: |
@@ -474,8 +476,11 @@ content: |
 ########################## Send to GitHub code ##########################
 code: |
   if not task_performed('sent to github', persistent=True):
+    saved_uuid
     if github_user in allowed_github_users:
-      issue_url = make_github_issue(github_user, github_repo, template=issue_template)
+      issue_url
+      if issue_url and saved_uuid:
+        set_session_github_url(saved_uuid, issue_url)
       if not issue_url and al_error_email:
         log(f"Unable to create issue on repo {github_repo}, falling back to emailing {al_error_email}")
         send_email(to=al_error_email, subject=f"{github_repo} - {issue_template.subject_as_html(trim=True)}", template=issue_template)
@@ -486,4 +491,10 @@ code: |
       log(f"Unable to create issue on repo {github_repo}, falling back to emailing {al_error_email}")
       send_email(to=al_error_email, subject=f"{github_repo} - {issue_template.subject_as_html(trim=True)}", template=issue_template)
     mark_task_as_performed('sent to github', persistent=True)
-  send_to_github = True  
+  send_to_github = True
+---
+code: |
+  saved_uuid = save_session_info(interview=filename, session_id=orig_session_id, template=issue_template)
+---
+code: |
+  issue_url = make_github_issue(github_user, github_repo, template=issue_template)

--- a/docassemble/GithubFeedbackForm/data/questions/feedback.yml
+++ b/docassemble/GithubFeedbackForm/data/questions/feedback.yml
@@ -281,17 +281,20 @@ fields:
     field: share_other_details   
     datatype: area
     required: False
-#  - label: |
-#      **Share my specific answers with an administrator**[BR]
-#      You can optionally share your answers on the online form with an
-#      administrator. Only two Suffolk University employees can view
-#      this information. It will not be made public.
-#      [BR]
-#      If you say no, it may be harder for us to track down the problem,
-#      but we will still try our best.
-#      We will not contact you either way.
-#    field: share_interview_answers
-#    datatype: yesnoradio
+  - label: |
+      **Share my specific answers with an administrator**[BR]
+      You can optionally share your answers on the online form with an
+      administrator. Only server administrators can view
+      this information. It will not be made public.
+      [BR]
+      If you say no, it may be harder for us to track down the problem,
+      but we will still try our best.
+      We will not contact you either way.
+    field: share_interview_answers
+    datatype: yesnoradio
+    show if:
+      code: |
+        server_share_answers
 ---
 id: confusing
 question: |
@@ -476,10 +479,11 @@ content: |
 ########################## Send to GitHub code ##########################
 code: |
   if not task_performed('sent to github', persistent=True):
-    saved_uuid
+    if actually_share_answers:
+      saved_uuid
     if github_user in allowed_github_users:
       issue_url
-      if issue_url and saved_uuid:
+      if actually_share_answers and issue_url and saved_uuid:
         set_session_github_url(saved_uuid, issue_url)
       if not issue_url and al_error_email:
         log(f"Unable to create issue on repo {github_repo}, falling back to emailing {al_error_email}")
@@ -498,3 +502,9 @@ code: |
 ---
 code: |
   issue_url = make_github_issue(github_user, github_repo, template=issue_template)
+---
+code: |
+  server_share_answers = get_config("allow_feedback_session_linking", False)
+---
+code: |
+  actually_share_answers = server_share_answers and (get_config('debug') or showifdef('share_interview_answers', False))

--- a/docassemble/GithubFeedbackForm/github_issue.py
+++ b/docassemble/GithubFeedbackForm/github_issue.py
@@ -97,7 +97,6 @@ def save_session_info(interview=None, session_id=None, template=None, body=None)
         guid_map = {}
 
       uuid_for_session = str(uuid.uuid4())
-      body += f'\nUID for Session: {uuid_for_session}'
       guid_map[uuid_for_session] = {'interview': interview, 'session_id': session_id, 'body': body}
       red.set_data(redis_feedback_key, guid_map)
       return uuid_for_session

--- a/docassemble/GithubFeedbackForm/github_issue.py
+++ b/docassemble/GithubFeedbackForm/github_issue.py
@@ -1,16 +1,20 @@
-import requests
-import json
 import importlib
-from docassemble.base.util import log, get_config, interview_url
+import json
+import requests
+import uuid
+from typing import Optional
+from docassemble.base.util import log, get_config, interview_url, DARedis
 
 # reference: https://gist.github.com/JeffPaine/3145490
 # https://docs.github.com/en/free-pro-team@latest/rest/reference/issues#create-an-issue
 
 # Authentication for user filing issue (must have read/write access to
 # repository to add issue to)
-__all__ = ['valid_github_issue_config', 'make_github_issue', 'feedback_link']
+__all__ = ['valid_github_issue_config', 'make_github_issue', 'save_session_info', 'set_session_github_url', 'feedback_link', 'redis_feedback_key']
 USERNAME = get_config('github issues',{}).get('username')
 TOKEN = get_config('github issues',{}).get('token')
+
+redis_feedback_key = 'docassemble-GithubFeedbackForm:feedback_info'
 
 def valid_github_issue_config():
   return bool(TOKEN)
@@ -21,8 +25,8 @@ def feedback_link(user_info_object=None,
                    github_user:str=None, 
                    variable:str=None, 
                    question_id:str=None,
-                   package_version=None,
-                   filename=None)->str:
+                   package_version:str=None,
+                   filename:str=None)->str:
   """
   Helper function to get a link to the GitHub feedback form.
   For simple usage, it should be enough to call
@@ -43,9 +47,10 @@ def feedback_link(user_info_object=None,
     try:
       _package_version = str(importlib.import_module(user_info_object.package).__version__)
     except:
-      _package_version = "playground"    
+      _package_version = "playground"
     if get_config('github issues',{}).get('default repository owner'):
       _github_user = get_config('github issues',{}).get('default repository owner')
+    _session_id = user_info_object.session
   
   # Allow keyword params to override any info from the user_info() object
   # We will try pulling the repo owner name from the Docassemble config
@@ -57,7 +62,7 @@ def feedback_link(user_info_object=None,
     _github_repo = github_repo
   else:
     _github_repo = "demo"
-    _github_user = "suffolklitlab-issues"    
+    _github_user = "suffolklitlab-issues"
   if variable:
     _variable = variable
   if question_id:
@@ -69,7 +74,7 @@ def feedback_link(user_info_object=None,
   
   if not i:
     i = "docassemble.GithubFeedbackForm:feedback.yml"
-    
+
   return interview_url(i=i, 
     github_repo=_github_repo, 
     github_user=_github_user, 
@@ -77,14 +82,52 @@ def feedback_link(user_info_object=None,
     question_id=_question_id, 
     package_version=_package_version, 
     filename=_filename,
-    local=False,reset=1)                         
+    session_id=_session_id,
+    local=False,reset=1)
 
-def make_github_issue(repo_owner, repo_name, template=None, title=None, body=None):
+def save_session_info(interview=None, session_id=None, template=None, body=None) -> Optional[dict]:
+    """Saves session information along with the feedback in a redis DB"""
+    if template:
+      body = template.content
+
+    if interview and session_id:
+      red = DARedis()
+      guid_map = red.get_data(redis_feedback_key)
+      if not guid_map:
+        guid_map = {}
+
+      uuid_for_session = str(uuid.uuid4())
+      body += f'\nUID for Session: {uuid_for_session}'
+      guid_map[uuid_for_session] = {'interview': interview, 'session_id': session_id, 'body': body}
+      red.set_data(redis_feedback_key, guid_map)
+      return uuid_for_session
+    else: # can happen if the forwarding interview didn't pass session info
+      return None
+
+def set_session_github_url(uuid_for_session:str, github_url:str) -> bool:
+    """Returns true if save was successful"""
+    red = DARedis()
+    guid_map = red.get_data(redis_feedback_key)
+    if not guid_map:
+      guid_map = {}
+
+    if uuid_for_session in guid_map:
+      guid_map[uuid_for_session]['html_url'] = github_url
+      red.set_data(redis_feedback_key, guid_map)
+      return True
+    else:
+      log(f'Cannot find {uuid_for_session} in redis DB')
+      return False
+
+def make_github_issue(repo_owner, repo_name, template=None, title=None, body=None) -> Optional[str]:
     """
     Create a new Github issue and return the URL.
+
+    template - the docassemble template for the github issue. Overrides `title` and `body` if provided.
+    title - the title for the github issue
+    body - the body of the github issue
     """
-    url = 'https://api.github.com/repos/%s/%s/issues' % (repo_owner, repo_name)
-    # log(url)
+    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/issues"
     # Headers
     if not TOKEN:
       log("Error creating issues: No valid GitHub token provided.")


### PR DESCRIPTION
First pass at solving #3. Allows admin users to examine user sessions in more detail to reproduce bugs and
strange behavior.

It stores the information in a DARedis database, and also adds a separate
admin-only interview to directly jump to the session in question

Can also save information on the server even if github isn't set up (though not
optimized for that use yet).