### PR TITLE
Fix user perm link

### DIFF
--- a/docassemble/GithubFeedbackForm/data/questions/feedback.yml
+++ b/docassemble/GithubFeedbackForm/data/questions/feedback.yml
@@ -294,7 +294,13 @@ fields:
     datatype: yesnoradio
     show if:
       code: |
-        server_share_answers
+        server_share_answers and not get_config('debug')
+  - note: |
+      Your answers will be shared with a server administrator to help
+      track down the problem. It will not be made public.
+    show if:
+      code: |
+        server_share_answers and get_config('debug')
 ---
 id: confusing
 question: |

--- a/docassemble/GithubFeedbackForm/data/questions/feedback.yml
+++ b/docassemble/GithubFeedbackForm/data/questions/feedback.yml
@@ -510,7 +510,7 @@ code: |
   issue_url = make_github_issue(github_user, github_repo, template=issue_template)
 ---
 code: |
-  server_share_answers = get_config("allow_feedback_session_linking", False)
+  server_share_answers = get_config("allow feedback session linking", False)
 ---
 code: |
   actually_share_answers = server_share_answers and (get_config('debug') or showifdef('share_interview_answers', False))


### PR DESCRIPTION
If you're on a debug server (test or dev) and the admin has enabled sharing,
always share. Adds a note to let users know this is happenning.

The logic is that answers on a test or dev server shouldn't be PII, and when
filling out a bug, it shouldn't be compromising an anonymous position either
(unlike filling out a negative review might be).