### PR TITLE
Ask if users want to be in a research panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ This package is designed to support the following workflow:
    any specific questions, add a logo, etc.
 
 5. If you enabled `feedback session linking` in the configuration, you can visit the
-   `https://myserverurl.com/start/GithubFeedbackForm/browse_feedback_sessions.yml` to view
+   `https://myserverurl.com/start/GithubFeedbackForm/browse_feedback_sessions` to view
+
    sessions that users agreed to link to their description of a bug, so you can reproduce the
    issue. This interview also will show you the list of emails of users who agreed to join a
    qualitative research panel.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ into a Docassemble interview. Makes it easy to collect per-page feedback.
 This package is designed to support the following workflow:
 
 1. Work is stored on a public GitHub repository, or at least, you setup a repository to collect feedback.
-1. There is one package per "interview"/"app".
-2. Each question block has a unique question ID.
-3. Preferably--questions are triggered in an interview order block. If you use a series of `mandatory`
+2. There is one package per "interview"/"app".
+3. Each question block has a unique question ID.
+4. Preferably--questions are triggered in an interview order block. If you use a series of `mandatory`
   blocks instead of a single mandatory block, the `variable` listed in the bug report may not be as useful.
 
 ## Getting started
@@ -16,26 +16,31 @@ This package is designed to support the following workflow:
 1. Create a new GitHub user and create a personal access token on it. The personal access
    token needs minimal permissions. Specifically, it needs to be allowed to make pull requests.
    Pull request access is allowed for anyone by default when you create a new, public GitHub repository.
-3. Edit your config, and create a block like this:
+2. Edit your config, and create a block like this:
 
-```yaml
-github issues:
-  username: "YOUR_NEW_DEDICATED_ISSUE_CREATION_ACCOUNT"
-  token: "..." # A valid GitHub personal access token associated with the username above
-  default repository owner: YOUR_GITHUB_USER_OR_ORG_HERE
-  allowed repository owners: # List the repo that your account will be allowed to create issues on
-    - YOUR_GITHUB_USER_OR_ORG_HERE 
-    - SECOND_GITHUB_USER_OR_ORG
-```
+   ```yaml
+   github issues:
+     username: "YOUR_NEW_DEDICATED_ISSUE_CREATION_ACCOUNT"
+     token: "..." # A valid GitHub personal access token associated with the username above
+     default repository owner: YOUR_GITHUB_USER_OR_ORG_HERE
+     allowed repository owners: # List the repo that your account will be allowed to create issues on
+       - YOUR_GITHUB_USER_OR_ORG_HERE 
+       - SECOND_GITHUB_USER_OR_ORG
+     # If user agrees, will save the session ID of their current interview on the server and link it to their
+     # feedback issue on github. You can browser the linked sessions in `browse_feedback_sessions.yml`
+     feedback session linking: True
+     # Will ask users filling in feedback if they want to be in a panel, and get their email if they want to
+     ask panel: True
+   ```
 
-  Note that it is important to provide a list of allowed repository owners.
-  This is used to prevent your form from being used to spam GitHub 
-  repositories with feedback.
-  
+   Note that it is important to provide a list of allowed repository owners.
+   This is used to prevent your form from being used to spam GitHub
+   repositories with feedback.
+
 3. Add a link on each page, in the footer or `under` area.  
    You can use the `feedback_link()` function to add a link, like this:
    `[:comment-dots: Feedback](${ feedback_link(user_info()) } ){:target="_blank"}`
-   
+
    Optional parameters:
     - `i`: the feedback form, like: docassemble.AssemblyLine:feedback.yml
     - `github_repo`: repo name, like: docassemble-AssemblyLine
@@ -44,42 +49,53 @@ github issues:
     - `question_id`:  id of the current question, like: intro
     - `package_version`: version number of the current package
     - `filename`: filename of the interview the user is providing feedback on.
-    
-    Each has a sensible default. Most likely, you will limit your custom
-    parameters to the `github_repo` if you want feedback links to work
-    from the docassemble playground.
-    
-    You will also need to include the `github_issue.py` module in your parent interview,
-    like this: 
-    ```yaml
-    ---
-    modules:
-      - docassemble.GithubFeedbackForm.github_issue
-    ```
-    
+
+   Each has a sensible default. Most likely, you will limit your custom
+   parameters to the `github_repo` if you want feedback links to work
+   from the docassemble playground.
+
+   You will also need to include the `github_issue.py` module in your parent interview,
+   like this:
+
+   ```yaml
+   ---
+   modules:
+     - docassemble.GithubFeedbackForm.github_issue
+   ```
+
 4. Optionally, create your own feedback.yml file. If you want a custom feedback.yml,
    it should look like this, with whatever customizations you choose:
 
-```yaml
-include:
-  - docassemble.GithubFeedbackForm:feedback.yml
----
-code: |
-  al_feedback_form_title = "Your title here"  
----
-code: |
-  # This email will be used ONLY if there is no valid GitHub config
-  al_error_email = "your_email@yourdomain.com"
----
-template: al_how_to_get_legal_help
-content: |
-  If you need more help, these are free resources:
+   ```yaml
+   include:
+     - docassemble.GithubFeedbackForm:feedback.yml
+   ---
+   code: |
+     al_feedback_form_title = "Your title here"  
+   ---
+   code: |
+     # This email will be used ONLY if there is no valid GitHub config
+     al_error_email = "your_email@yourdomain.com"
+   ---
+   code: |
+     # Will be the name of the Github label added to new issues
+     al_github_label = 'user feedback'
+   ---
+   template: al_how_to_get_legal_help
+   content: |
+     If you need more help, these are free resources:
 
-  ... [INCLUDE STATE-SPECIFIC RESOURCES]      
-```
+     ... [INCLUDE STATE-SPECIFIC RESOURCES]
+   ```
 
-You may also want to customize the metadata: title, exit url and override 
-any specific questions, add a logo, etc.    
+   You may also want to customize the metadata: title, exit url and override
+   any specific questions, add a logo, etc.
+
+5. If you enabled `feedback session linking` in the configuration, you can visit the
+   `https://myserverurl.com/start/GithubFeedbackForm/browse_feedback_sessions.yml` to view
+   sessions that users agreed to link to their description of a bug, so you can reproduce the
+   issue. This interview also will show you the list of emails of users who agreed to join a
+   qualitative research panel.
 
 ## Author
 

--- a/docassemble/GithubFeedbackForm/data/questions/browse_feedback_sessions.yml
+++ b/docassemble/GithubFeedbackForm/data/questions/browse_feedback_sessions.yml
@@ -40,6 +40,17 @@ fields:
     choices:
       code: |
         guids
+help:
+  label: |
+    View Panelists
+  content: |
+    % for panelist_email in potential_panelists():
+    % if isinstance(panelist_email, bytes):
+    * ${ panelist_email.decode('utf-8') }
+    % else:
+    * ${ str(panelist_email) }
+    % endif
+    % endfor
 ---
 if: not guids
 question: |

--- a/docassemble/GithubFeedbackForm/data/questions/browse_feedback_sessions.yml
+++ b/docassemble/GithubFeedbackForm/data/questions/browse_feedback_sessions.yml
@@ -44,11 +44,15 @@ help:
   label: |
     View Panelists
   content: |
-    % for panelist_email in potential_panelists():
-    % if isinstance(panelist_email, bytes):
-    * ${ panelist_email.decode('utf-8') }
+    ${ view_panelists }
+---
+template: view_panelists
+content: |
+    % for email_and_time in potential_panelists():
+    % if isinstance(email_and_time[0], bytes):
+    * ${ email_and_time[0].decode('utf-8') }, at ${ email_and_time[1]}
     % else:
-    * ${ str(panelist_email) }
+    * ${ str(panelist_email) }, at ${ email_and_time[1]}
     % endif
     % endfor
 ---
@@ -56,6 +60,11 @@ if: not guids
 question: |
   No feedback sessions to view
 event: feedback_guid
+help:
+  label: |
+    View Panelists
+  content: |
+    ${ view_panelists }
 ---
 code: |
   guid_map = red.get_data(redis_feedback_key) or {}

--- a/docassemble/GithubFeedbackForm/data/questions/feedback.yml
+++ b/docassemble/GithubFeedbackForm/data/questions/feedback.yml
@@ -56,6 +56,10 @@ code: |
 code: |
   allowed_github_users = get_config('github issues',{}).get('allowed repository owners') or ["suffolklitlab","suffolklitlab-issues"]
 ---
+code: server_share_answers = get_config("github issues", {}).get("feedback session linking", False)
+---
+code: server_ask_panel = get_config("github issues", {}).get("ask panel", False)
+---
 code: github_user = url_args.get('github_user', default_github_user_or_organization) or "suffolklitlab-issues"
 ---
 code: github_repo = url_args.get('github_repo', default_repository) or "demo"
@@ -111,6 +115,23 @@ fields:
         server_share_answers and not get_config('debug')
       variable: reason
       is: something
+  - label: |
+      **Would you like to be contacted to be a part of user feedback panel?**
+    field: would_be_on_panel
+    datatype: yesnoradio
+    show if:
+      code: |
+        server_ask_panel and not get_config('debug')
+      variable: reason
+      is: something
+  - label: |
+      **What is your email?**
+    field: panel_email
+    datatype: email
+    default: ${ user_info().email }
+    show if:
+      variable: would_be_on_panel
+      is: True
 continue button field: intro
 ---
 if: |
@@ -269,6 +290,8 @@ code: |
   if not task_performed('sent to github', persistent=True):
     if actually_share_answers:
       saved_uuid
+    if showifdef('would_be_on_panel', False):
+      add_panel_participant(panel_email)
     if github_user in allowed_github_users:
       issue_url
       if actually_share_answers and issue_url and saved_uuid:
@@ -289,13 +312,10 @@ code: |
   saved_uuid = save_session_info(interview=filename, session_id=orig_session_id, template=issue_template)
 ---
 code: |
-  issue_url = make_github_issue(github_user, github_repo, template=issue_template, label=github_label)
----
-code: |
-  server_share_answers = get_config("allow feedback session linking", False)
+  issue_url = make_github_issue(github_user, github_repo, template=issue_template, label=al_github_label)
 ---
 code: |
   actually_share_answers = server_share_answers and (get_config('debug') or showifdef('share_interview_answers', False))
 ---
 code: |
-  github_label = 'user feedback'
+  al_github_label = 'user feedback'

--- a/docassemble/GithubFeedbackForm/data/questions/feedback.yml
+++ b/docassemble/GithubFeedbackForm/data/questions/feedback.yml
@@ -116,7 +116,7 @@ fields:
       variable: reason
       is: something
   - label: |
-      **Would you like to be contacted to be a part of user feedback panel?**
+      **Would you like to be contacted to be a part of a user feedback panel?**
     field: would_be_on_panel
     datatype: yesnoradio
     show if:

--- a/docassemble/GithubFeedbackForm/github_issue.py
+++ b/docassemble/GithubFeedbackForm/github_issue.py
@@ -91,7 +91,7 @@ def feedback_link(user_info_object=None,
 ############################################
 ## Panel particitpants are managed through a Redis ZSet (a sorted/scored set).
 ## The score is the timestamp of when they responded, so we can fetch newer
-## respondants (more likely to accept a follow up interview).
+## respondents (more likely to accept a follow up interview).
 ## https://redis.io/docs/manual/data-types/#sorted-sets
 
 def add_panel_participant(email:str):


### PR DESCRIPTION
Saves their email and when they responded in a Redis ZSet, which can be viewed in the
browse_feedback_sessions interview. Is completely separate from session linking, 
though I added the feature to view panelists behind the `browse_feedback_session.yml`.
Fixes #8.

Also makes a few small changes to previous features (#15, #9):
* moves configuration options under the `github issues` key, so all of the related keys are together.
* changes the name of the overridable `github_label` to `al_github_label` to match the other variables that
  can be overriden.
  
Finally, I added the above features to the README, and cleaned it up a bit (not ending spaces, etc.)