### PR TITLE
Changed session backend to use SQLAlchemy

### DIFF
--- a/docassemble/GithubFeedbackForm/data/questions/browse_feedback_sessions.yml
+++ b/docassemble/GithubFeedbackForm/data/questions/browse_feedback_sessions.yml
@@ -1,5 +1,5 @@
 modules:
-  - .github_issue
+  - .feedback_on_server
 ---
 objects:
   - red: DARedis
@@ -24,7 +24,7 @@ subquestion: |
   ${ action_button_html(url_action('open_session'), label='Open Session', color='secondary') }
 ---
 metadata:
-  title: Browse Feedback Sessions
+  title: Browse Interview Feedback
   short title: Browse Feedback
   temporary session: True
   required privileges:
@@ -33,7 +33,7 @@ metadata:
 if: ids
 id: main browse screen
 question: |
-  Select a feedback session to browse
+  Select feedback to browse
 fields:
   - Feedback Session: feedback_id
     datatype: dropdown
@@ -58,7 +58,7 @@ content: |
 ---
 if: not ids
 question: |
-  No feedback sessions to view
+  No feedback to view
 event: feedback_id
 help:
   label: |
@@ -67,10 +67,11 @@ help:
     ${ view_panelists }
 ---
 code: |
-  id_map = get_all_session_info()
+  id_map = get_all_feedback_info()
 ---
 code: |
-  ids = {row_id: info['html_url'] if info.get('html_url') else info.get('session_id') for row_id, info in id_map.items()}
+  ids = {row_id: info['html_url'] if info.get('html_url') else info.get('session_id') 
+      for row_id, info in id_map.items() if info.get('session_id')}
 ---
 event: open_session
 code: |

--- a/docassemble/GithubFeedbackForm/data/questions/browse_feedback_sessions.yml
+++ b/docassemble/GithubFeedbackForm/data/questions/browse_feedback_sessions.yml
@@ -6,20 +6,20 @@ objects:
 ---
 mandatory: True
 code: |
-  feedback_guid
+  feedback_id
   feedback_info
 ---
 event: feedback_info
 question: Feedback Info
 subquestion: |
   ## Body
-  ${ guid_map[feedback_guid].get('body') }
+  ${ id_map[feedback_id]['body'] }
 
   ## Github URL
-  ${ guid_map[feedback_guid].get('html_url') }
+  ${ id_map[feedback_id]['html_url'] }
 
   ## Session ID
-  ${ guid_map[feedback_guid].get('interview', '')}:${ guid_map[feedback_guid].get('session_id', '')}
+  ${ id_map[feedback_id]['interview'] }:${ id_map[feedback_id]['session_id'] }
 
   ${ action_button_html(url_action('open_session'), label='Open Session', color='secondary') }
 ---
@@ -30,16 +30,16 @@ metadata:
   required privileges:
     - admin
 ---
-if: guids
+if: ids
 id: main browse screen
 question: |
   Select a feedback session to browse
 fields:
-  - Feedback GUID: feedback_guid
+  - Feedback Session: feedback_id
     datatype: dropdown
     choices:
       code: |
-        guids
+        ids
 help:
   label: |
     View Panelists
@@ -56,10 +56,10 @@ content: |
     % endif
     % endfor
 ---
-if: not guids
+if: not ids
 question: |
   No feedback sessions to view
-event: feedback_guid
+event: feedback_id
 help:
   label: |
     View Panelists
@@ -67,12 +67,12 @@ help:
     ${ view_panelists }
 ---
 code: |
-  guid_map = red.get_data(redis_feedback_key) or {}
+  id_map = get_all_session_info()
 ---
 code: |
-  guids = {guid: (info['html_url'] if 'html_url' in info else info.get('session_id') ) for guid, info in guid_map.items()}
+  ids = {row_id: info['html_url'] if info.get('html_url') else info.get('session_id') for row_id, info in id_map.items()}
 ---
 event: open_session
 code: |
-  info = guid_map[feedback_guid]
+  info = id_map[feedback_id]
   response(url=interview_url(i=info['interview'], session=info['session_id'], temporary=1))

--- a/docassemble/GithubFeedbackForm/data/questions/feedback.yml
+++ b/docassemble/GithubFeedbackForm/data/questions/feedback.yml
@@ -1,10 +1,10 @@
 ---
 modules:
   - .github_issue
+  - .feedback_on_server
 ---
 include:
   - docassemble.ALToolbox:collapse_template.yml
----
 ---
 metadata:
   title: User Feedback
@@ -15,7 +15,7 @@ features:
   labels above fields: True
   question back button: True
 ---
-code: al_feedback_form_title = "Court Forms Online"  
+code: al_feedback_form_title = "Court Forms Online"
 ---
 code: |
   # This email will be used ONLY if there is no valid GitHub config
@@ -295,7 +295,7 @@ code: |
     if github_user in allowed_github_users:
       issue_url
       if actually_share_answers and issue_url and saved_uuid:
-        set_session_github_url(saved_uuid, issue_url)
+        set_feedback_github_url(saved_uuid, issue_url)
       if not issue_url and al_error_email:
         log(f"Unable to create issue on repo {github_repo}, falling back to emailing {al_error_email}")
         send_email(to=al_error_email, subject=f"{github_repo} - {issue_template.subject_as_html(trim=True)}", template=issue_template)
@@ -309,7 +309,7 @@ code: |
   send_to_github = True
 ---
 code: |
-  saved_uuid = save_session_info(interview=filename, session_id=orig_session_id, template=issue_template)
+  saved_uuid = save_feedback_info(interview=filename, session_id=orig_session_id, template=issue_template)
 ---
 code: |
   issue_url = make_github_issue(github_user, github_repo, template=issue_template, label=al_github_label)

--- a/docassemble/GithubFeedbackForm/feedback_on_server.py
+++ b/docassemble/GithubFeedbackForm/feedback_on_server.py
@@ -1,0 +1,88 @@
+import importlib
+
+from typing import Optional, Iterable, Tuple
+from datetime import datetime
+from sqlalchemy import insert, update, select, Text, DateTime, Table, Column,\
+    String, Integer, MetaData, create_engine, func
+from docassemble.base.util import DARedis, log
+from docassemble.base.sql import alchemy_url
+
+__all__ = ['save_feedback_info', 'set_feedback_github_url', 'redis_panel_emails_key', 'add_panel_participant',
+    'potential_panelists', 'get_all_feedback_info']
+
+redis_panel_emails_key = 'docassemble-GithubFeedbackForm:panel_emails'
+
+############################################
+## Panel particitpants are managed through a Redis ZSet (a sorted/scored set).
+## The score is the timestamp of when they responded, so we can fetch newer
+## respondents (more likely to accept a follow up interview).
+## https://redis.io/docs/manual/data-types/#sorted-sets
+
+def add_panel_participant(email:str):
+    """Adds this email to a list of potential participants for a qualitative research panel.
+    Adds the email and when they responded, as we shouldn't link their feedback to their identity at all.
+    """
+    red = DARedis()
+    red.zadd(redis_panel_emails_key, {email: datetime.now().timestamp()})
+
+def potential_panelists() -> Iterable[Tuple[str, datetime]]:
+    red = DARedis()
+    return [(item, datetime.fromtimestamp(score)) for item, score in red.zrange(redis_panel_emails_key, 0, -1, withscores=True)]
+
+###################################
+## Using SQLAlchemy to save / retrieve session information that is linked
+## to specific feedback issues
+
+db_url = alchemy_url('db')
+engine = create_engine(db_url)
+
+metadata_obj = MetaData()
+
+## This table functions as both storage for bug report-session links,
+## and for more general on-server feedback, prompted for at the end of interviews
+feedback_session_table = Table(
+  "feedback_session",
+  metadata_obj,
+  Column('id', Integer, primary_key=True),
+  Column('interview', String),
+  Column('session_id', String),
+  Column('body', Text),
+  Column('html_url', String)
+)
+
+metadata_obj.create_all(engine)
+
+def save_feedback_info(interview, *, session_id=None, template=None, body=None) -> Optional[str]:
+    """Saves feedback along with optional session information in a SQL DB"""
+    if template:
+      body = template.content
+
+    if interview and (session_id or body):
+      stmt = insert(feedback_session_table).values(interview=interview, session_id=session_id, body=body)
+      with engine.begin() as conn:
+        result = conn.execute(stmt)
+        id_for_feedback = result.inserted_primary_key[0]
+
+      return id_for_feedback
+    else: # can happen if the forwarding interview didn't pass session info
+      return None
+
+def set_feedback_github_url(id_for_feedback:str, github_url:str) -> bool:
+    """Returns true if save was successful"""
+    stmt = update(feedback_session_table).where(feedback_session_table.c.id == id_for_feedback).values(html_url=github_url)
+    with engine.begin() as conn:
+      result = conn.execute(stmt)
+    if result.rowcount == 0:
+      log(f'Cannot find {id_for_feedback} in redis DB')
+      return False
+    return True
+
+def get_all_feedback_info(interview=None) -> Iterable:
+    if interview:
+        stmt = select(feedback_session_table).where(feedback_session_table.c.interview == interview)
+    else:
+        stmt = select(feedback_session_table)
+    with engine.begin() as conn:
+        results = conn.execute(stmt)
+        # Turn into literal dict because DA is too eager to save / load SQLAlchemy objects into the interview SQL
+        return {str(row['id']): dict(row) for row in results.mappings()}


### PR DESCRIPTION
In anticipation of scaling better with thousands of feedback items.
The only significant change is to change the GUID to a normal, incrementing SQL int id. GUID isn't a SQL standard thing (only a postgres thing), and tbh we don't get too much from it, so the flexibility of working with other dbs is probably better than keeping it.

Fixes #14.