### PR TITLE
Don't send emails for Spam

### DIFF
--- a/docassemble/GithubFeedbackForm/data/questions/feedback.yml
+++ b/docassemble/GithubFeedbackForm/data/questions/feedback.yml
@@ -321,6 +321,8 @@ code: |
       log(f"Unable to create issue on repo {github_repo}, falling back to emailing {al_error_email}")
       send_email(to=al_error_email, subject=f"{github_repo} - {issue_template.subject_as_html(trim=True)}", template=issue_template)
     mark_task_as_performed('sent to github', persistent=True)
+  else:
+    log("Already sent feedback to github from a feedback interview, not going to send again")
   send_to_github = True
 ---
 code: |

--- a/docassemble/GithubFeedbackForm/data/questions/feedback.yml
+++ b/docassemble/GithubFeedbackForm/data/questions/feedback.yml
@@ -44,7 +44,7 @@ image sets:
       confusion: confusion.svg
       lifebuoy: lifebuoy.svg
       love: love.svg
-      enhancement: enhance.svg  
+      enhancement: enhance.svg
 ---
 # This is the repository that Github issue will be created on if
 # the repository is not passed as a URL argument
@@ -52,9 +52,6 @@ code: default_repository = 'docassemble-AssemblyLine'
 ---
 code: |
   default_github_user_or_organization = get_config('github issues',{}).get('default repository owner') or 'suffolklitlab'
----
-code: |
-  allowed_github_users = get_config('github issues',{}).get('allowed repository owners') or ["suffolklitlab","suffolklitlab-issues"]
 ---
 code: server_share_answers = get_config("github issues", {}).get("feedback session linking", False)
 ---
@@ -301,25 +298,29 @@ content: |
   % endif
 ---
 ########################## Send to GitHub code ##########################
+need:
+  - question_id
+  - variable
+  - package_version
+  - filename
 code: |
   if not task_performed('sent to github', persistent=True):
     if actually_share_answers:
       saved_uuid
     if showifdef('would_be_on_panel', False):
       add_panel_participant(panel_email)
-    if github_user in allowed_github_users:
-      issue_url
-      if actually_share_answers and issue_url and saved_uuid:
+    issue_url
+    if issue_url:
+      if actually_share_answers and saved_uuid:
         set_feedback_github_url(saved_uuid, issue_url)
-      if not issue_url and al_error_email:
+    else:
+      al_error_email
+      log(f"This form was not able to add an issue on the {github_user}/{github_repo} repo. Check your config.")
+      if al_error_email:
         log(f"Unable to create issue on repo {github_repo}, falling back to emailing {al_error_email}")
         send_email(to=al_error_email, subject=f"{github_repo} - {issue_template.subject_as_html(trim=True)}", template=issue_template)
-      elif not issue_url:
+      else:
         log(f"~~~USER FEEDBACK~~~ {github_repo} -{issue_template.subject_as_html(trim=True)} - {issue_template.content_as_html(trim=True)}")
-    else:
-      log(f"This form is not permitted to add issues on the {github_user} account. Check your config.")
-      log(f"Unable to create issue on repo {github_repo}, falling back to emailing {al_error_email}")
-      send_email(to=al_error_email, subject=f"{github_repo} - {issue_template.subject_as_html(trim=True)}", template=issue_template)
     mark_task_as_performed('sent to github', persistent=True)
   else:
     log("Already sent feedback to github from a feedback interview, not going to send again")

--- a/docassemble/GithubFeedbackForm/data/questions/feedback.yml
+++ b/docassemble/GithubFeedbackForm/data/questions/feedback.yml
@@ -316,7 +316,7 @@ code: |
     else:
       al_error_email
       log(f"This form was not able to add an issue on the {github_user}/{github_repo} repo. Check your config.")
-      if al_error_email:
+      if al_error_email and not is_likely_spam(issue_template.content):
         log(f"Unable to create issue on repo {github_repo}, falling back to emailing {al_error_email}")
         send_email(to=al_error_email, subject=f"{github_repo} - {issue_template.subject_as_html(trim=True)}", template=issue_template)
       else:

--- a/docassemble/GithubFeedbackForm/github_issue.py
+++ b/docassemble/GithubFeedbackForm/github_issue.py
@@ -9,7 +9,7 @@ from docassemble.base.util import log, get_config, interview_url
 
 # Authentication for user filing issue (must have read/write access to
 # repository to add issue to)
-__all__ = ["valid_github_issue_config", "make_github_issue", "feedback_link"]
+__all__ = ["valid_github_issue_config", "make_github_issue", "feedback_link", "is_likely_spam"]
 USERNAME = get_config("github issues", {}).get("username")
 
 
@@ -100,6 +100,11 @@ def feedback_link(
     )
 
 
+def is_likely_spam(body) -> bool:
+    if any([url in body for url in ["boostleadgeneration.com/", "jumboleadmagnet.com/"]]):
+        return True
+    return False
+
 def make_github_issue(
     repo_owner:str, repo_name:str, template=None, title=None, body=None, label=None
 ) -> Optional[str]:
@@ -148,6 +153,11 @@ def make_github_issue(
     if template:
         title = template.subject
         body = template.content
+
+    if is_likely_spam(body):
+        log("Error creating issue: the body of the issue is caught as spam")
+        return None
+
     # Create our issue
     data = {
         "title": title,

--- a/docassemble/GithubFeedbackForm/github_issue.py
+++ b/docassemble/GithubFeedbackForm/github_issue.py
@@ -9,18 +9,29 @@ from docassemble.base.util import log, get_config, interview_url
 
 # Authentication for user filing issue (must have read/write access to
 # repository to add issue to)
-__all__ = ["valid_github_issue_config", "make_github_issue", "feedback_link", "is_likely_spam"]
+__all__ = [
+    "valid_github_issue_config",
+    "make_github_issue",
+    "feedback_link",
+    "is_likely_spam",
+]
 USERNAME = get_config("github issues", {}).get("username")
 
 
 def _get_token() -> Optional[str]:
     return (get_config("github issues") or {}).get("token")
 
+
 def _get_allowed_repo_owners() -> List[str]:
-    return (get_config("github issues") or {}).get("allowed repository owners") or ["suffolklitlab", "suffolklitlab-issues"]
+    return (get_config("github issues") or {}).get("allowed repository owners") or [
+        "suffolklitlab",
+        "suffolklitlab-issues",
+    ]
+
 
 def valid_github_issue_config():
     return bool(_get_token())
+
 
 def feedback_link(
     user_info_object=None,
@@ -101,12 +112,15 @@ def feedback_link(
 
 
 def is_likely_spam(body) -> bool:
-    if any([url in body for url in ["boostleadgeneration.com/", "jumboleadmagnet.com/"]]):
+    if any(
+        [url in body for url in ["boostleadgeneration.com/", "jumboleadmagnet.com/"]]
+    ):
         return True
     return False
 
+
 def make_github_issue(
-    repo_owner:str, repo_name:str, template=None, title=None, body=None, label=None
+    repo_owner: str, repo_name: str, template=None, title=None, body=None, label=None
 ) -> Optional[str]:
     """
     Create a new Github issue and return the URL.
@@ -118,11 +132,15 @@ def make_github_issue(
     make_issue_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/issues"
     # Headers
     if not valid_github_issue_config():
-        log("Error creating issue: No valid GitHub token provided. Check your config and see https://github.com/SuffolkLITLab/docassemble-GithubFeedbackForm#getting-started")
+        log(
+            "Error creating issue: No valid GitHub token provided. Check your config and see https://github.com/SuffolkLITLab/docassemble-GithubFeedbackForm#getting-started"
+        )
         return None
-    
+
     if repo_owner not in _get_allowed_repo_owners():
-        log(f"Error creating issue: this form is not permitted to add issues to repositories owned by {repo_owner}. Check your config and see https://github.com/SuffolkLITLab/docassemble-GithubFeedbackForm#getting-started")
+        log(
+            f"Error creating issue: this form is not permitted to add issues to repositories owned by {repo_owner}. Check your config and see https://github.com/SuffolkLITLab/docassemble-GithubFeedbackForm#getting-started"
+        )
         return None
 
     headers = {


### PR DESCRIPTION
Particularly interested if we think the spam filter is strong enough, I wasn't sure if wanted to filter all URLs, which might catch some people off guard.

Realizing now we could also client-side validate as well. Might be within scope, if we want it.

Also fix silent issue where we would still make Github issues when the `allowed_repo_owners` said we couldn't. Put the logic for that in the python function so it can be circumnavigated now.