### PR TITLE
Fix typo and expected behavior of repo owners

### DIFF
--- a/docassemble/GithubFeedbackForm/feedback_on_server.py
+++ b/docassemble/GithubFeedbackForm/feedback_on_server.py
@@ -118,7 +118,7 @@ def set_feedback_github_url(id_for_feedback: str, github_url: str) -> bool:
     with engine.begin() as conn:
         result = conn.execute(stmt)
     if result.rowcount == 0:
-        log(f"Cannot find {id_for_feedback} in redis DB")
+        log(f"Cannot find {id_for_feedback} in DB")
         return False
     return True
 
@@ -147,7 +147,7 @@ def save_good_or_bad(
         _interview = user_info_object.filename
         try:
             _package_version = str(
-                importlib.import_module(user_info_object.package).__verison__
+                importlib.import_module(user_info_object.package).__version__
             )
         except:
             _package_version = "playground"
@@ -169,7 +169,7 @@ def save_good_or_bad(
 
 def get_good_or_bad(interview: str = None):
     """Retrieves user's aggregate reactions to an interview (how many reactions
-    and the average score of them), grouped by interview and package verison"""
+    and the average score of them), grouped by interview and package version"""
     stmt = select(
         good_or_bad_table.c.interview,
         good_or_bad_table.c.version,

--- a/docassemble/GithubFeedbackForm/github_issue.py
+++ b/docassemble/GithubFeedbackForm/github_issue.py
@@ -23,10 +23,14 @@ def _get_token() -> Optional[str]:
 
 
 def _get_allowed_repo_owners() -> List[str]:
-    return (get_config("github issues") or {}).get("allowed repository owners") or [
-        "suffolklitlab",
-        "suffolklitlab-issues",
-    ]
+    github_config = (get_config("github issues") or {})
+    repo_owners = github_config.get("allowed repository owners")
+    if not repo_owners:
+      default_owner = github_config.get("default reporitory owner")
+      repo_owners = [default_owner] if default_owner else []
+    if not repo_owners:
+      repo_owners = ["suffolklitlab", "suffolklitlab-issues"]
+    return [owner.lower() for owner in repo_owners]
 
 
 def valid_github_issue_config():
@@ -137,7 +141,7 @@ def make_github_issue(
         )
         return None
 
-    if repo_owner not in _get_allowed_repo_owners():
+    if repo_owner.lower() not in _get_allowed_repo_owners():
         log(
             f"Error creating issue: this form is not permitted to add issues to repositories owned by {repo_owner}. Check your config and see https://github.com/SuffolkLITLab/docassemble-GithubFeedbackForm#getting-started"
         )

--- a/docassemble/GithubFeedbackForm/github_issue.py
+++ b/docassemble/GithubFeedbackForm/github_issue.py
@@ -23,13 +23,13 @@ def _get_token() -> Optional[str]:
 
 
 def _get_allowed_repo_owners() -> List[str]:
-    github_config = (get_config("github issues") or {})
+    github_config = get_config("github issues") or {}
     repo_owners = github_config.get("allowed repository owners")
     if not repo_owners:
-      default_owner = github_config.get("default reporitory owner")
-      repo_owners = [default_owner] if default_owner else []
+        default_owner = github_config.get("default reporitory owner")
+        repo_owners = [default_owner] if default_owner else []
     if not repo_owners:
-      repo_owners = ["suffolklitlab", "suffolklitlab-issues"]
+        repo_owners = ["suffolklitlab", "suffolklitlab-issues"]
     return [owner.lower() for owner in repo_owners]
 
 


### PR DESCRIPTION
* start looking for the `__version__` attribute of a package, not the incorrect `__verison` that we were before
* If `allowed repository owners` isn't set, use the `default repository owner` value instead of falling back to hardcoded defaults.
* use the lowercase of all repository owner strings; Github doesn't care about org or username cases, so we shouldn't as well