### PR TITLE
Archive feedback, show and hide it, etc.

### DIFF
--- a/docassemble/GithubFeedbackForm/alembic.ini
+++ b/docassemble/GithubFeedbackForm/alembic.ini
@@ -100,6 +100,8 @@ handlers =
 qualname = alembic
 
 [handler_console]
+#class = FileHandler
+#args = ('/tmp/testing_super.log',)
 class = StreamHandler
 args = (sys.stderr,)
 level = NOTSET

--- a/docassemble/GithubFeedbackForm/alembic/env.py
+++ b/docassemble/GithubFeedbackForm/alembic/env.py
@@ -49,6 +49,7 @@ def run_migrations_offline() -> None:
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
+        # Typo is intentional; we're stuck with it; https://github.com/SuffolkLITLab/docassemble-GithubFeedbackForm/pull/43#issuecomment-1783498410
         version_table="al_feedback_on_sevrver_version",
     )
 
@@ -73,6 +74,7 @@ def run_migrations_online() -> None:
         context.configure(
             connection=connection,
             target_metadata=target_metadata,
+            # Typo is intentional; we're stuck with it; https://github.com/SuffolkLITLab/docassemble-GithubFeedbackForm/pull/43#issuecomment-1783498410
             version_table="al_feedback_on_sevrver_version",
         )
 

--- a/docassemble/GithubFeedbackForm/alembic/env.py
+++ b/docassemble/GithubFeedbackForm/alembic/env.py
@@ -49,7 +49,7 @@ def run_migrations_offline() -> None:
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
-        version_table="al_feedback_on_server_version",
+        version_table="al_feedback_on_sevrver_version",
     )
 
     with context.begin_transaction():

--- a/docassemble/GithubFeedbackForm/alembic/env.py
+++ b/docassemble/GithubFeedbackForm/alembic/env.py
@@ -73,7 +73,7 @@ def run_migrations_online() -> None:
         context.configure(
             connection=connection,
             target_metadata=target_metadata,
-            version_table="al_feedback_on_sevrver_version",
+            version_table="al_feedback_on_server_version",
         )
 
         with context.begin_transaction():

--- a/docassemble/GithubFeedbackForm/alembic/env.py
+++ b/docassemble/GithubFeedbackForm/alembic/env.py
@@ -49,8 +49,7 @@ def run_migrations_offline() -> None:
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
-        # Typo is intentional; we're stuck with it; https://github.com/SuffolkLITLab/docassemble-GithubFeedbackForm/pull/43#issuecomment-1783498410
-        version_table="al_feedback_on_sevrver_version",
+        version_table="al_feedback_on_server_version",
     )
 
     with context.begin_transaction():
@@ -74,8 +73,7 @@ def run_migrations_online() -> None:
         context.configure(
             connection=connection,
             target_metadata=target_metadata,
-            # Typo is intentional; we're stuck with it; https://github.com/SuffolkLITLab/docassemble-GithubFeedbackForm/pull/43#issuecomment-1783498410
-            version_table="al_feedback_on_sevrver_version",
+            version_table="al_feedback_on_server_version",
         )
 
         with context.begin_transaction():

--- a/docassemble/GithubFeedbackForm/alembic/env.py
+++ b/docassemble/GithubFeedbackForm/alembic/env.py
@@ -73,7 +73,7 @@ def run_migrations_online() -> None:
         context.configure(
             connection=connection,
             target_metadata=target_metadata,
-            version_table="al_feedback_on_server_version",
+            version_table="al_feedback_on_sevrver_version",
         )
 
         with context.begin_transaction():

--- a/docassemble/GithubFeedbackForm/alembic/env.py
+++ b/docassemble/GithubFeedbackForm/alembic/env.py
@@ -11,8 +11,8 @@ from alembic import context
 # access to the values within the .ini file in use.
 config = context.config
 
-section = config.config_ini_section
-config.set_section_option(section, "DB_PASS", os.getenv("DB_PASS", ""))
+#section = config.config_ini_section
+#config.set_section_option(section, "DB_PASS", os.getenv("DB_PASS", ""))
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.

--- a/docassemble/GithubFeedbackForm/alembic/env.py
+++ b/docassemble/GithubFeedbackForm/alembic/env.py
@@ -11,8 +11,8 @@ from alembic import context
 # access to the values within the .ini file in use.
 config = context.config
 
-#section = config.config_ini_section
-#config.set_section_option(section, "DB_PASS", os.getenv("DB_PASS", ""))
+# section = config.config_ini_section
+# config.set_section_option(section, "DB_PASS", os.getenv("DB_PASS", ""))
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.

--- a/docassemble/GithubFeedbackForm/alembic/versions/542797f969ea_initial_alembic_migration.py
+++ b/docassemble/GithubFeedbackForm/alembic/versions/542797f969ea_initial_alembic_migration.py
@@ -7,8 +7,6 @@ Create Date: 2023-10-09 17:06:05.463730
 """
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.engine import reflection
-
 
 # revision identifiers, used by Alembic.
 revision = "542797f969ea"
@@ -19,11 +17,7 @@ depends_on = None
 
 # Code based on https://github.com/talkpython/data-driven-web-apps-with-flask
 def table_does_not_exist(table, schema=None):
-    config = op.get_context().config
-    engine = sa.engine_from_config(
-        config.get_section(config.config_ini_section), prefix="sqlalchemy."
-    )
-    insp = reflection.Inspector.from_engine(engine)
+    insp = sa.inspect(op.get_bind())
     return insp.has_table(table, schema) == False
 
 

--- a/docassemble/GithubFeedbackForm/alembic/versions/8821926028d6_archiving.py
+++ b/docassemble/GithubFeedbackForm/alembic/versions/8821926028d6_archiving.py
@@ -18,12 +18,8 @@ depends_on = None
 
 
 # Code based on https://github.com/talkpython/data-driven-web-apps-with-flask
-def table_has_column(table, column, engine=None):
-    config = op.get_context().config
-    if not engine:
-        engine = sa.engine_from_config(
-            config.get_section(config.config_ini_section), prefix='sqlalchemy.')
-    insp = sa.inspect(engine)
+def table_has_column(table, column):
+    insp = sa.inspect(op.get_bind())
     has_column = False
     for col in insp.get_columns(table):
         if column not in col['name']:
@@ -33,11 +29,8 @@ def table_has_column(table, column, engine=None):
 
 
 def upgrade() -> None:
-    config = op.get_context().config
-    engine = sa.engine_from_config(
-        config.get_section(config.config_ini_section), prefix='sqlalchemy.')
-    make_archived = not table_has_column("feedback_session", "archived", engine)
-    make_datetime = not table_has_column("feedback_session", "datetime", engine)
+    make_archived = not table_has_column("feedback_session", "archived")
+    make_datetime = not table_has_column("feedback_session", "datetime")
     if make_archived:
         op.add_column(
             "feedback_session",

--- a/docassemble/GithubFeedbackForm/alembic/versions/8821926028d6_archiving.py
+++ b/docassemble/GithubFeedbackForm/alembic/versions/8821926028d6_archiving.py
@@ -23,7 +23,7 @@ depends_on = None
 
 def upgrade() -> None:
     log("Upgrading to latest")
-    op.add_column("feedback_session", sa.Column("archived", sa.Boolean))
+    op.add_column("feedback_session", sa.Column("archived", sa.Boolean, server_default="False"))
     op.add_column("feedback_session", sa.Column("datetime", sa.TIMESTAMP(timezone=True), server_default=str(datetime.min)))
 
 

--- a/docassemble/GithubFeedbackForm/alembic/versions/8821926028d6_archiving.py
+++ b/docassemble/GithubFeedbackForm/alembic/versions/8821926028d6_archiving.py
@@ -7,6 +7,7 @@ Create Date: 2023-10-18 11:45:07.370329
 """
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.engine import reflection
 from datetime import datetime
 
 # revision identifiers, used by Alembic.
@@ -16,16 +17,36 @@ branch_labels = None
 depends_on = None
 
 
+# Code based on https://github.com/talkpython/data-driven-web-apps-with-flask
+def table_has_column(table, column):
+    config = op.get_context().config
+    engine = sa.engine_from_config(
+        config.get_section(config.config_ini_section), prefix="sqlalchemy."
+    )
+    insp = reflection.Inspector.from_engine(engine)
+    has_column = False
+    for col in insp.get_columns(table):
+        if column not in col["name"]:
+            continue
+        has_column = True
+    return has_column
+
+
 def upgrade() -> None:
-    op.add_column(
-        "feedback_session", sa.Column("archived", sa.Boolean, server_default="False")
-    )
-    op.add_column(
-        "feedback_session",
-        sa.Column(
-            "datetime", sa.TIMESTAMP(timezone=True), server_default=str(datetime.min)
-        ),
-    )
+    if not table_has_column("feedback_session", "archived"):
+        op.add_column(
+            "feedback_session",
+            sa.Column("archived", sa.Boolean, server_default="False"),
+        )
+    if not table_has_column("feedback_session", "datetime"):
+        op.add_column(
+            "feedback_session",
+            sa.Column(
+                "datetime",
+                sa.TIMESTAMP(timezone=True),
+                server_default=str(datetime.min),
+            ),
+        )
 
 
 def downgrade() -> None:

--- a/docassemble/GithubFeedbackForm/alembic/versions/8821926028d6_archiving.py
+++ b/docassemble/GithubFeedbackForm/alembic/versions/8821926028d6_archiving.py
@@ -1,0 +1,27 @@
+"""archiving
+
+Revision ID: 8821926028d6
+Revises: 542797f969ea
+Create Date: 2023-10-18 11:45:07.370329
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from datetime import datetime
+
+
+# revision identifiers, used by Alembic.
+revision = '8821926028d6'
+down_revision = '542797f969ea'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("feedback_session", sa.Column("archived", sa.Boolean))
+    op.add_column("feedback_session", sa.Column("datetime", sa.TIMESTAMP(timezone=True), server_default=datetime.min))
+
+
+def downgrade() -> None:
+    op.drop_column("feedback_session", "archived")
+    op.drop_column("feedback_session", "datetime")

--- a/docassemble/GithubFeedbackForm/alembic/versions/8821926028d6_archiving.py
+++ b/docassemble/GithubFeedbackForm/alembic/versions/8821926028d6_archiving.py
@@ -7,7 +7,6 @@ Create Date: 2023-10-18 11:45:07.370329
 """
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.engine import reflection
 from datetime import datetime
 
 # revision identifiers, used by Alembic.

--- a/docassemble/GithubFeedbackForm/alembic/versions/8821926028d6_archiving.py
+++ b/docassemble/GithubFeedbackForm/alembic/versions/8821926028d6_archiving.py
@@ -10,6 +10,10 @@ import sqlalchemy as sa
 from datetime import datetime
 
 
+def log(msg):
+  with open("/tmp/tmp_logging.txt", "a") as f:
+    f.write(msg)
+
 # revision identifiers, used by Alembic.
 revision = '8821926028d6'
 down_revision = '542797f969ea'
@@ -18,8 +22,9 @@ depends_on = None
 
 
 def upgrade() -> None:
+    log("Upgrading to latest")
     op.add_column("feedback_session", sa.Column("archived", sa.Boolean))
-    op.add_column("feedback_session", sa.Column("datetime", sa.TIMESTAMP(timezone=True), server_default=datetime.min))
+    op.add_column("feedback_session", sa.Column("datetime", sa.TIMESTAMP(timezone=True), server_default=str(datetime.min)))
 
 
 def downgrade() -> None:

--- a/docassemble/GithubFeedbackForm/alembic/versions/8821926028d6_archiving.py
+++ b/docassemble/GithubFeedbackForm/alembic/versions/8821926028d6_archiving.py
@@ -21,7 +21,7 @@ def table_has_column(table, column):
     insp = sa.inspect(op.get_bind())
     has_column = False
     for col in insp.get_columns(table):
-        if column not in col['name']:
+        if column not in col["name"]:
             continue
         has_column = True
     return has_column

--- a/docassemble/GithubFeedbackForm/alembic/versions/8821926028d6_archiving.py
+++ b/docassemble/GithubFeedbackForm/alembic/versions/8821926028d6_archiving.py
@@ -10,15 +10,22 @@ import sqlalchemy as sa
 from datetime import datetime
 
 # revision identifiers, used by Alembic.
-revision = '8821926028d6'
-down_revision = '542797f969ea'
+revision = "8821926028d6"
+down_revision = "542797f969ea"
 branch_labels = None
 depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column("feedback_session", sa.Column("archived", sa.Boolean, server_default="False"))
-    op.add_column("feedback_session", sa.Column("datetime", sa.TIMESTAMP(timezone=True), server_default=str(datetime.min)))
+    op.add_column(
+        "feedback_session", sa.Column("archived", sa.Boolean, server_default="False")
+    )
+    op.add_column(
+        "feedback_session",
+        sa.Column(
+            "datetime", sa.TIMESTAMP(timezone=True), server_default=str(datetime.min)
+        ),
+    )
 
 
 def downgrade() -> None:

--- a/docassemble/GithubFeedbackForm/alembic/versions/8821926028d6_archiving.py
+++ b/docassemble/GithubFeedbackForm/alembic/versions/8821926028d6_archiving.py
@@ -9,11 +9,6 @@ from alembic import op
 import sqlalchemy as sa
 from datetime import datetime
 
-
-def log(msg):
-  with open("/tmp/tmp_logging.txt", "a") as f:
-    f.write(msg)
-
 # revision identifiers, used by Alembic.
 revision = '8821926028d6'
 down_revision = '542797f969ea'
@@ -22,7 +17,6 @@ depends_on = None
 
 
 def upgrade() -> None:
-    log("Upgrading to latest")
     op.add_column("feedback_session", sa.Column("archived", sa.Boolean, server_default="False"))
     op.add_column("feedback_session", sa.Column("datetime", sa.TIMESTAMP(timezone=True), server_default=str(datetime.min)))
 

--- a/docassemble/GithubFeedbackForm/data/questions/browse_feedback_sessions.yml
+++ b/docassemble/GithubFeedbackForm/data/questions/browse_feedback_sessions.yml
@@ -16,10 +16,14 @@ mandatory: True
 code: |
   feedback_summary
 ---
+reconsider:
+  - text_reviews
 event: feedback_summary 
 question: |
   Feedback Summary
 subquestion: |
+  ${ action_button_html(url_action('toggle_archived'), label="Show archived" if not show_archived else "Hide archived", color="secondary")}
+
   ${ tabbed_templates_html("Feedback tabs", reviews_table_template, feedback_select_template)}
 help:
   label: |
@@ -44,19 +48,25 @@ content: |
   % for interview, review_list in text_reviews.items():
   <h3 class="h5">In ${ interview }</h3>
   % for review in review_list:
+  % if review['archived']:
+  **ARCHIVED**
+  % endif
+
+  On ${ review['datetime'] }:
+
   > ${ review['body'] }
 
   % if not review.get('html_url'):
   ${ action_button_html(prefill_github_issue_url(repo_name=interview.split(":")[0].replace(".", "-"), title="User feedback", body=review['body'], label=al_github_label), label="Make a github issue") }
   % else:
   [Link to Github issue](${ review.get('html_url') })
+
   % endif
-
   % if review.get('session_id'):
-  ## Session ID
-  ${ review['interview'] }:${ review.get('session_id') }
-
   ${ action_button_html(url_action('open_session', interview=review['interview'], session_id=review.get('session_id')), label='Open Session', color='secondary') }
+  % endif
+  % if not review['archived']:
+  ${ action_button_html(url_action('mark_as_archived', feedback_id=review['id']), label="Archive", color="danger")}
   % endif
 
   ---
@@ -88,11 +98,13 @@ content: |
     % endfor
 ---
 code: |
-  id_map = get_all_feedback_info()
+  show_archived = False
 ---
+depends on:
+  - show_archived
 code: |
   text_reviews = {}
-  for row_id, info in id_map.items():
+  for row_id, info in get_all_feedback_info(None, include_archived=show_archived).items():
     info['id'] = row_id
     if info['interview'] in text_reviews:
       text_reviews[info['interview']].append(info)
@@ -107,6 +119,15 @@ code: |
       response(url=interview_url(i=action_argument('interview'), session=info.get('session_id'), temporary=1))
   else:
       log("Need interview and session ID to open session", "danger")
+---
+event: mark_as_archived
+code: |
+  feedback_id = action_argument('feedback_id')
+  mark_archived(feedback_id)
+---
+event: toggle_archived
+code: |
+  show_archived = not show_archived
 ---
 code: |
   al_github_label = 'user feedback'

--- a/docassemble/GithubFeedbackForm/feedback_on_server.py
+++ b/docassemble/GithubFeedbackForm/feedback_on_server.py
@@ -17,8 +17,14 @@ from sqlalchemy import (
     create_engine,
     func,
 )
-from docassemble.base.util import DARedis, log
+from sqlalchemy.ext.declarative import declarative_base
+from docassemble.base.util import DARedis
 from docassemble.base.sql import alchemy_url, connect_args, upgrade_db
+
+def log(msg):
+  with open("/tmp/tmp_logging.txt", "a") as f:
+    f.write(msg)
+
 
 __all__ = [
     "save_feedback_info",
@@ -61,11 +67,8 @@ def potential_panelists() -> Iterable[Tuple[str, datetime]]:
 ## Using SQLAlchemy to save / retrieve session information that is linked
 ## to specific feedback issues, or just to store private feedback
 
-db_url = alchemy_url("db")
-conn_args = connect_args("db")
-engine = create_engine(db_url, connect_args=conn_args)
-
-metadata_obj = MetaData()
+Base = declarative_base()
+metadata_obj = Base.metadata
 
 ## This table functions as both storage for bug report-session links,
 ## and for more general on-server feedback, prompted for at the end of interviews
@@ -90,8 +93,14 @@ good_or_bad_table = Table(
     Column("datetime", DateTime),
 )
 
+
+db_url = alchemy_url("db")
+conn_args = connect_args("db")
+engine = create_engine(db_url, connect_args=conn_args)
+
 metadata_obj.create_all(engine)
 
+log("Calling upgrade db")
 upgrade_db(
     db_url,
     __file__,

--- a/docassemble/GithubFeedbackForm/feedback_on_server.py
+++ b/docassemble/GithubFeedbackForm/feedback_on_server.py
@@ -100,6 +100,8 @@ engine = create_engine(db_url, connect_args=conn_args)
 
 metadata_obj.create_all(engine)
 
+metadata_obj.bind = engine
+
 log("Calling upgrade db")
 upgrade_db(
     db_url,

--- a/docassemble/GithubFeedbackForm/feedback_on_server.py
+++ b/docassemble/GithubFeedbackForm/feedback_on_server.py
@@ -100,6 +100,7 @@ upgrade_db(
     db_url,
     __file__,
     engine,
+    # Typo is intentional; we're stuck with it; https://github.com/SuffolkLITLab/docassemble-GithubFeedbackForm/pull/43#issuecomment-1783498410
     version_table="al_feedback_on_sevrver_version",
     conn_args=conn_args,
 )

--- a/docassemble/GithubFeedbackForm/feedback_on_server.py
+++ b/docassemble/GithubFeedbackForm/feedback_on_server.py
@@ -100,7 +100,7 @@ upgrade_db(
     db_url,
     __file__,
     engine,
-    version_table="al_feedback_on_server_version",
+    version_table="al_feedback_on_sevrver_version",
     conn_args=conn_args,
 )
 

--- a/docassemble/GithubFeedbackForm/feedback_on_server.py
+++ b/docassemble/GithubFeedbackForm/feedback_on_server.py
@@ -114,7 +114,11 @@ def save_feedback_info(
 
     if interview and (session_id or body):
         stmt = insert(feedback_session_table).values(
-            interview=interview, session_id=session_id, body=body, datetime=datetime.now(), archived=False
+            interview=interview,
+            session_id=session_id,
+            body=body,
+            datetime=datetime.now(),
+            archived=False,
         )
         with engine.begin() as conn:
             result = conn.execute(stmt)
@@ -142,6 +146,7 @@ def set_feedback_github_url(id_for_feedback: str, github_url: str) -> bool:
         return False
     return True
 
+
 def mark_archived(id_for_feedback: str) -> bool:
     stmt = (
         update(feedback_session_table)
@@ -155,16 +160,13 @@ def mark_archived(id_for_feedback: str) -> bool:
         return False
     return True
 
+
 def get_all_feedback_info(interview=None, include_archived=False) -> Iterable:
     stmt = select(feedback_session_table)
     if interview:
-        stmt = stmt.where(
-            feedback_session_table.c.interview == interview
-        )
+        stmt = stmt.where(feedback_session_table.c.interview == interview)
     if not include_archived:
-        stmt = stmt.where(
-          feedback_session_table.c.archived == False
-        )
+        stmt = stmt.where(feedback_session_table.c.archived == False)
     with engine.begin() as conn:
         results = conn.execute(stmt)
         # Turn into literal dict because DA is too eager to save / load SQLAlchemy objects into the interview SQL

--- a/docassemble/GithubFeedbackForm/feedback_on_server.py
+++ b/docassemble/GithubFeedbackForm/feedback_on_server.py
@@ -18,13 +18,8 @@ from sqlalchemy import (
     func,
 )
 from sqlalchemy.ext.declarative import declarative_base
-from docassemble.base.util import DARedis
+from docassemble.base.util import DARedis, log
 from docassemble.base.sql import alchemy_url, connect_args, upgrade_db
-
-def log(msg):
-  with open("/tmp/tmp_logging.txt", "a") as f:
-    f.write(msg)
-
 
 __all__ = [
     "save_feedback_info",
@@ -99,10 +94,8 @@ conn_args = connect_args("db")
 engine = create_engine(db_url, connect_args=conn_args)
 
 metadata_obj.create_all(engine)
-
 metadata_obj.bind = engine
 
-log("Calling upgrade db")
 upgrade_db(
     db_url,
     __file__,


### PR DESCRIPTION
Adds the ability to archive feedback, and show older feedback. Tried to keep it very slim.

* fixed a typo from #41 that prevented proper upgrading: tested upgrading multiple times from the last main, and it's been working. 
* Used `declarative_base()`'s metadata instead of making our own, otherwise DA doesn't seem to know about our tables.
* existing feedback gets a date of 0001-01-01, to make it clear that we don't know the date.

Fixes #39.