### PR TITLE
Fix silent validation DA issue with panel question

### DIFF
--- a/docassemble/GithubFeedbackForm/data/questions/feedback.yml
+++ b/docassemble/GithubFeedbackForm/data/questions/feedback.yml
@@ -131,6 +131,8 @@ fields:
   - note: |
       We will contact you for the feedback panel by email.
     show if:
+      code: |
+        server_ask_panel and not get_config('debug')
       variable: would_be_on_panel
       is: True
   - label: |
@@ -139,6 +141,8 @@ fields:
     datatype: email
     default: ${ user_info().email if hasattr(user_info(), 'email') else '' }
     show if:
+      code: |
+        server_ask_panel and not get_config('debug')
       variable: would_be_on_panel
       is: True
 continue button field: intro


### PR DESCRIPTION
Docassemble has issues with certain show if'd fields being required. For some reason, hiding one field behind a show-if from a server config, and then hiding other fields behind that field caused validation issues for with latter fields, which shows no user indication becasue those fields aren't shown.

Fixed the issue by using the same server show if code on all of the fields. A bit redandant, it does fix the issue in my testing.

Fix #48

Let me know if this fixes the issue on y'all side @miabonardi, I'll merge if it does! 