### PR TITLE
Add spam classifier with google gemini flash 2.0 experimental and check for spam earlier

### DIFF
--- a/docassemble/GithubFeedbackForm/data/questions/feedback.yml
+++ b/docassemble/GithubFeedbackForm/data/questions/feedback.yml
@@ -311,26 +311,33 @@ need:
   - package_version
   - filename
 code: |
-  if not task_performed('issue noted', persistent=True):
-    saved_uuid
-    if showifdef('would_be_on_panel', False):
-      add_panel_participant(panel_email)
-    if should_send_to_github:
-      issue_url
-      if issue_url:
-        if saved_uuid:
-          set_feedback_github_url(saved_uuid, issue_url)
-      else:
-        al_error_email
-        log(f"This form was not able to add an issue on the {github_user}/{github_repo} repo. Check your config.")
-        if al_error_email and not is_likely_spam(issue_template.content):
-          log(f"Unable to create issue on repo {github_repo}, falling back to emailing {al_error_email}")
-          send_email(to=al_error_email, subject=f"{github_repo} - {issue_template.subject_as_html(trim=True)}", template=issue_template)
-        else:
-          log(f"~~~USER FEEDBACK~~~ {github_repo} -{issue_template.subject_as_html(trim=True)} - {issue_template.content_as_html(trim=True)}")
+  if is_likely_spam(issue_template.content):
+    log("Not saving feedback because it looks like spam")
     mark_task_as_performed('issue noted', persistent=True)
+    issue_url = None
+    saved_uuid = None
+    note_issue = False
   else:
-    log("Already sent feedback to github from a feedback interview, not going to send again")
+    if not task_performed('issue noted', persistent=True):
+      saved_uuid
+      if showifdef('would_be_on_panel', False):
+        add_panel_participant(panel_email)
+      if should_send_to_github:
+        issue_url
+        if issue_url:
+          if saved_uuid:
+            set_feedback_github_url(saved_uuid, issue_url)
+        else:
+          al_error_email
+          log(f"This form was not able to add an issue on the {github_user}/{github_repo} repo. Check your config.")
+          if al_error_email and not is_likely_spam(issue_template.content):
+            log(f"Unable to create issue on repo {github_repo}, falling back to emailing {al_error_email}")
+            send_email(to=al_error_email, subject=f"{github_repo} - {issue_template.subject_as_html(trim=True)}", template=issue_template)
+          else:
+            log(f"~~~USER FEEDBACK~~~ {github_repo} -{issue_template.subject_as_html(trim=True)} - {issue_template.content_as_html(trim=True)}")
+      mark_task_as_performed('issue noted', persistent=True)
+    else:
+      log("Already sent feedback to github from a feedback interview, not going to send again")
   note_issue = True
 ---
 code: |

--- a/docassemble/GithubFeedbackForm/data/questions/feedback.yml
+++ b/docassemble/GithubFeedbackForm/data/questions/feedback.yml
@@ -81,11 +81,11 @@ subquestion: |
   The information you type here will be publicly available. That means anyone
   will be able to see it. Use this form to tell us about problems that do not
   include any personal information.
-  
+
   ${ collapse_template(al_how_to_get_legal_help) }
 
   Thank you for telling us about your experience with this website.
-  
+
 fields:
   - no label: reason
     input type: radio
@@ -158,12 +158,12 @@ decoration: opinion
 subquestion: |
   This form is designed to be used by testers and community
   stakeholders.
-  
+
   The information you type here will be publicly available. That means anyone
   will be able to see it.
-  
+
   ${ collapse_template(al_how_to_get_legal_help) }
-  
+
 fields:
   - "**What would you like to tell us about?**": reason
     input type: radio
@@ -236,7 +236,7 @@ subject: |
   Do you need more help?
 content: |
   If you need more help, these are free resources:
-  
+
   - [Find Free Legal help - Legal Services Corporation](https://www.lsc.gov/about-lsc/what-legal-aid/get-legal-help)
 
   - [Hire a lawyer](https://www.americanbar.org/groups/legal_services/flh-home/flh-hire-a-lawyer/)
@@ -248,7 +248,7 @@ question: |
 decoration: lifebuoy
 subquestion: |
   We are sorry that we couldn't do more to help you.
-  
+
   ${ al_how_to_get_legal_help }
 
 buttons:
@@ -261,7 +261,7 @@ question: |
 decoration: opinion
 subquestion: |
   We appreciate you letting us know how we are doing.
-  
+
   % if issue_url:
   If you would like to track this issue, you can [follow 
   it](${issue_url}) on GitHub.
@@ -304,6 +304,8 @@ content: |
   % endif
 ---
 ########################## Send to GitHub code ##########################
+only sets:
+  - note_issue
 need:
   - should_send_to_github
   - question_id
@@ -311,33 +313,38 @@ need:
   - package_version
   - filename
 code: |
-  if is_likely_spam(issue_template.content):
+  if task_performed('issue noted'):
+    pass
+  elif is_likely_spam(issue_template.content):
     log("Not saving feedback because it looks like spam")
     mark_task_as_performed('issue noted', persistent=True)
-    issue_url = None
-    saved_uuid = None
-    note_issue = False
+    issue_url, saved_uuid = None
+    note_issue = False # End block early
   else:
-    if not task_performed('issue noted', persistent=True):
-      saved_uuid
-      if showifdef('would_be_on_panel', False):
-        add_panel_participant(panel_email)
-      if should_send_to_github:
-        issue_url
-        if issue_url:
-          if saved_uuid:
-            set_feedback_github_url(saved_uuid, issue_url)
+    saved_uuid # Trigger the code to save locally on the server and optionally link the session answers. We do this regardless of whether we send to GitHub
+    if showifdef('would_be_on_panel'):
+      add_panel_participant(panel_email)
+
+    if should_send_to_github:
+      issue_url # Trigger the code to save as a GitHub issue
+      if issue_url and saved_uuid:
+        # Link the GitHub issue to the saved feedback in database
+        set_feedback_github_url(saved_uuid, issue_url)
+      else:
+        log(f"This form was not able to add an issue on the {github_user}/{github_repo} repo. Check your config.")
+        if al_error_email:
+          log(f"Unable to create issue on repo {github_repo}, falling back to emailing {al_error_email}")
+          send_email(
+              to=al_error_email,
+              subject=f"{github_repo} - {issue_template.subject_as_html(trim=True)}",
+              template=issue_template
+          )
         else:
-          al_error_email
-          log(f"This form was not able to add an issue on the {github_user}/{github_repo} repo. Check your config.")
-          if al_error_email and not is_likely_spam(issue_template.content):
-            log(f"Unable to create issue on repo {github_repo}, falling back to emailing {al_error_email}")
-            send_email(to=al_error_email, subject=f"{github_repo} - {issue_template.subject_as_html(trim=True)}", template=issue_template)
-          else:
-            log(f"~~~USER FEEDBACK~~~ {github_repo} -{issue_template.subject_as_html(trim=True)} - {issue_template.content_as_html(trim=True)}")
-      mark_task_as_performed('issue noted', persistent=True)
-    else:
-      log("Already sent feedback to github from a feedback interview, not going to send again")
+          log(f"~~~USER FEEDBACK~~~ {github_repo} - {issue_template.subject_as_html(trim=True)} - {issue_template.content_as_html(trim=True)}")
+      else:
+        issue_url = None
+    mark_task_as_performed('issue noted', persistent=True)
+
   note_issue = True
 ---
 code: |

--- a/docassemble/GithubFeedbackForm/github_issue.py
+++ b/docassemble/GithubFeedbackForm/github_issue.py
@@ -186,7 +186,7 @@ def is_likely_spam_from_genai(
     Args:
         body (Optional[str]): the body of the issue
         context (Optional[str]): the context of the issue to help rate it as spam or not, defaults to a guided interview in the legal context
-        gemini_token (Optional[str]): the token for the Google Gemini Flash API
+        gemini_api_key (Optional[str]): the token for the Google Gemini Flash API
     """
     if not body:
         return False

--- a/docassemble/GithubFeedbackForm/github_issue.py
+++ b/docassemble/GithubFeedbackForm/github_issue.py
@@ -192,15 +192,17 @@ def is_likely_spam_from_genai(
     """
     if not body:
         return False
-    
-    model = model or get_config("github issues", {}).get("spam model", "gemini-2.0-flash-exp")
+
+    model = model or get_config("github issues", {}).get(
+        "spam model", "gemini-2.0-flash-exp"
+    )
     gemini_api_key = gemini_api_key or get_config("google gemini api key")
 
-    if not gemini_api_key: # not passed as a parameter OR in the global config
+    if not gemini_api_key:  # not passed as a parameter OR in the global config
         log("Not using Google Gemini Flash to check for spam: no API key provided")
         return False
 
-    if context is None: # empty string is a valid input
+    if context is None:  # empty string is a valid input
         context = "a guided interview in the legal context"
 
     try:
@@ -221,7 +223,9 @@ def is_likely_spam_from_genai(
         if response.text.strip() == "spam":
             return True
     except NameError:
-        log(f"Error using Google Gemini Flash: the `google.generativeai` module is not available")
+        log(
+            f"Error using Google Gemini Flash: the `google.generativeai` module is not available"
+        )
     except Exception as e:
         log(f"Error using Google Gemini Flash: {e}")
         return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,7 @@ exclude = '''(?x)(
 [[tool.mypy.overrides]]
 module = "docassemble.base.*"
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "google.*"
+ignore_missing_imports = true

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.GithubFeedbackForm',
       url='https://courtformsonline.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.ALToolbox>=0.6.0'],
+      install_requires=['docassemble.ALToolbox>=0.6.0', 'google-generativeai'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/GithubFeedbackForm/', package='docassemble.GithubFeedbackForm'),
      )


### PR DESCRIPTION
Fix #54 

This adds a basically free and optional spam filter to the feedback form, driven by Google Gemini.

If the user's message passes the keyword filter, it will be sent to Google Gemini flash 2.0 experimental for additional filtering. As of 1/3/2025, the free tier has a limit of 1,500 queries/day, plenty to handle the small volume of feedback form spam we've been dealing with (a dozen a month in some cases).

To use it, a `google gemini api key` must be added to the global configuration.

I also noticed that the existing spam filtering wasn't being used except when the form fell back to delivering an email. I'm not sure why that was the case but this should also solve that problem.