### PR TITLE
Don't disable existing loggers when Alembic runs

### DIFF
--- a/docassemble/GithubFeedbackForm/alembic/env.py
+++ b/docassemble/GithubFeedbackForm/alembic/env.py
@@ -17,7 +17,7 @@ config = context.config
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 # add your model's MetaData object here
 # for 'autogenerate' support


### PR DESCRIPTION
Python's documentation about this https://docs.python.org/3/library/logging.config.html#logging.config.fileConfig.
Alembic auto-generates this file, but I can't find other uses of it in Suffolk code (@nonprofittechy, I suggest you check LemmaLegal packages).

Found by finding that when logs were broken on servers (the prod and sometimes dev servers), `docassemble.webapps.server.sys_log.disabled == True`. Consulted https://stackoverflow.com/a/43279730/11416267 once I discovered that.

Tested and confirmed fixed locally on a localhost docassemble with the following (no good unit test :

* restart docassemble's python code (by saving the config and restarting the server)
* confirm the logs work by loading an interview with a unique log message, checking it's timestamp
* run the `GithubFeedbackForm/feedback.yml` interview
    * on older versions, no more logs will be output after that
    * on this fixed version, you should be able to trigger and see new logs