### PR TITLE
Added unit test to GitFeedbackForm and good/bad

### DIFF
--- a/docassemble/GithubFeedbackForm/feedback_on_server.py
+++ b/docassemble/GithubFeedbackForm/feedback_on_server.py
@@ -19,7 +19,7 @@ from sqlalchemy import (
     create_engine,
     func,
 )
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from alembic.config import Config
 from alembic import command
 from docassemble.base.util import DARedis, log

--- a/docassemble/GithubFeedbackForm/requirements.txt
+++ b/docassemble/GithubFeedbackForm/requirements.txt
@@ -2,3 +2,4 @@ docassemble.base>=1.4
 docassemble.webapp
 mypy
 types-requests
+testcontainers

--- a/docassemble/GithubFeedbackForm/test_feedback_db.py
+++ b/docassemble/GithubFeedbackForm/test_feedback_db.py
@@ -1,0 +1,35 @@
+from testcontainers.postgres import PostgresContainer
+from unittest import TestCase
+from unittest.mock import patch
+
+class TestFeedbackOnServer(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._postgres = PostgresContainer("postgres:16")
+        cls._postgres.start()
+        cls._psql_url = cls._postgres.get_connection_url()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._postgres.stop()
+
+    @patch("docassemble.base.sql.alchemy_url")
+    def test_minimal_db(self, url1):
+        url1.return_value = self.__class__._psql_url
+        from .feedback_on_server import save_good_or_bad, get_good_or_bad
+        save_good_or_bad(1, interview="unittest", version="1.0.0")
+        save_good_or_bad(-1, interview="unittest", version="1.0.0")
+
+        save_good_or_bad(1, interview="unittest", version="1.0.1")
+        save_good_or_bad(1, interview="unittest", version="1.0.1")
+        save_good_or_bad(1, interview="unittest", version="1.0.1")
+
+        ratings = get_good_or_bad("unittest")
+        self.assertEqual(len(ratings), 2)
+        self.assertListEqual([r["interview"] for r in ratings], ["unittest"]*2)
+        if ratings[0]['version'] == "1.0.1":
+          self.assertEqual(ratings[0]["average"], 1)
+          self.assertEqual(ratings[1]["average"], 0)
+        else:
+          self.assertEqual(ratings[0]["average"], 0)
+          self.assertEqual(ratings[1]["average"], 1)

--- a/docassemble/__init__.py
+++ b/docassemble/__init__.py
@@ -1,5 +1,0 @@
-try:
-    __import__('pkg_resources').declare_namespace(__name__)
-except ImportError:
-    __path__ = __import__('pkgutil').extend_path(__path__, __name__)
-

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 from fnmatch import fnmatchcase
 from distutils.util import convert_path
 
@@ -51,8 +51,7 @@ setup(name='docassemble.GithubFeedbackForm',
       author_email='qsteenhuis@suffolk.edu',
       license='The MIT License (MIT)',
       url='https://courtformsonline.org',
-      packages=find_packages(),
-      namespace_packages=['docassemble'],
+      packages=find_namespace_packages(),
       install_requires=['docassemble.ALToolbox>=0.6.0', 'google-generativeai'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/GithubFeedbackForm/', package='docassemble.GithubFeedbackForm'),


### PR DESCRIPTION
Mocks out the alchemy url function to point to a new postgres test container.

Also switched to using sql alchemy 2.0 declarative base function, not the deprecated one.

Mostly just to have some sort of unittests on the feedback form so the action doesn't fail (they are probably necessary, given the amount of python code / tight DB integration).