### PR TITLE
Store github_repo_name and github_user in the table so "Make github issue" button works in more circumstances

### DIFF
--- a/docassemble/GithubFeedbackForm/alembic/versions/5b46c3a6f9b7_add_github_user_and_repo.py
+++ b/docassemble/GithubFeedbackForm/alembic/versions/5b46c3a6f9b7_add_github_user_and_repo.py
@@ -1,0 +1,26 @@
+"""add github user and repo
+
+Revision ID: 5b46c3a6f9b7
+Revises: 8821926028d6
+Create Date: 2025-07-31 10:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '5b46c3a6f9b7'
+down_revision = '8821926028d6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('feedback_session', sa.Column('github_user', sa.String(), nullable=True))
+    op.add_column('feedback_session', sa.Column('github_repo_name', sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('feedback_session', 'github_user')
+    op.drop_column('feedback_session', 'github_repo_name')

--- a/docassemble/GithubFeedbackForm/data/questions/browse_feedback_sessions.yml
+++ b/docassemble/GithubFeedbackForm/data/questions/browse_feedback_sessions.yml
@@ -57,7 +57,11 @@ content: |
   > ${ review['body'] }
 
   % if not review.get('html_url'):
+  % if review.get('github_user'):
+  ${ action_button_html(prefill_github_issue_url(repo_owner=review.get('github_user'), repo_name=review.get('github_repo_name'), title="User feedback", body=review['body'], label=al_github_label), label="Make a github issue") }
+  % else:
   ${ action_button_html(prefill_github_issue_url(repo_name=interview.split(":")[0].replace(".", "-"), title="User feedback", body=review['body'], label=al_github_label), label="Make a github issue") }
+  % endif
   % else:
   [Link to Github issue](${ review.get('html_url') })
 

--- a/docassemble/GithubFeedbackForm/data/questions/embedded_review.yml
+++ b/docassemble/GithubFeedbackForm/data/questions/embedded_review.yml
@@ -23,7 +23,7 @@ event: review_text_event
 code: |
   review_text = action_argument('review_text')
   did_react = True
-  save_feedback_info(user_info().filename, body=review_text)
+  save_feedback_info(user_info().filename, body=review_text, github_user=github_user, github_repo_name=github_repo_name)
 ---
 code: |
   def only_once_review_widget(

--- a/docassemble/GithubFeedbackForm/feedback_on_server.py
+++ b/docassemble/GithubFeedbackForm/feedback_on_server.py
@@ -107,6 +107,8 @@ feedback_session_table = Table(
     Column("html_url", String),
     Column("archived", Boolean),
     Column("datetime", DateTime),
+    Column("github_user", String, nullable=True),
+    Column("github_repo_name", String, nullable=True),
 )
 
 good_or_bad_table = Table(
@@ -136,7 +138,13 @@ upgrade_db(
 
 
 def save_feedback_info(
-    interview: str, *, session_id: Optional[str] = None, template=None, body=None
+    interview: str,
+    *,
+    session_id: Optional[str] = None,
+    template=None,
+    body=None,
+    github_user: Optional[str] = None,
+    github_repo_name: Optional[str] = None,
 ) -> Optional[str]:
     """Saves feedback along with optional session information in a SQL DB"""
     if template:
@@ -149,6 +157,8 @@ def save_feedback_info(
             body=body,
             datetime=datetime.now(),
             archived=False,
+            github_user=github_user,
+            github_repo_name=github_repo_name,
         )
         with engine.begin() as conn:
             result = conn.execute(stmt)

--- a/docassemble/GithubFeedbackForm/github_issue.py
+++ b/docassemble/GithubFeedbackForm/github_issue.py
@@ -336,7 +336,10 @@ def prefill_github_issue_url(
             or "suffolklitlab"
         )
     if not repo_name:
-        repo_name = "docassemble-AssemblyLine"  # TODO(brycew): should this be the default repo? it is in `feedback.yml`
+        repo_name = (
+            get_config("github issues", {}).get("default repository name")
+            or "[REPO_NAME_UNDEFINED]"
+        )
 
     if template:
         title = template.subject
@@ -345,7 +348,7 @@ def prefill_github_issue_url(
     payload = {"title": title, "body": body}
     url_params = urlencode(payload, quote_via=quote_plus)
 
-    return f"https://github.com/{repo_owner}/{repo_name}/issues/new?{url_params}"
+    return f"https://github.com/{repo_owner}/{repo_name}/issues/new?{url_params}" 
 
 
 def make_github_issue(


### PR DESCRIPTION
Before this fix, the thumbs up/down widget didn't store the github user or repo name in the database, so the "Make a github issue" was inferred from a combo of the running filename and the global config. As a result it only worked in very specific circumstances: specifically, if "default github owner" matched the owner of the repo, and the running package was installed serverwide and had a matching github repo name.

This PR matches the behavior of the normal github feedback form page, where both of those values can be provided.

Fix #72

Added alembic migration to accompany.