### PR TITLE
Remove google.generativeai dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ This package is designed to support the following workflow:
      feedback session linking: True
      # Will ask users filling in feedback if they want to be in a panel, and get their email if they want to
      ask panel: True
+     # (optional) If you need better protection from spam feedback, 
+     # adding the below, and installing the `google.generativeai` package
+     # will use Gemini AI as an additional filter.
+     google gemini api key: ...
+     spam model: "gemini-2.0-flash-exp" # the default
    ```
 
    Note that it is important to provide a list of allowed repository owners.

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(name='docassemble.GithubFeedbackForm',
       license='The MIT License (MIT)',
       url='https://courtformsonline.org',
       packages=find_namespace_packages(),
-      install_requires=['docassemble.ALToolbox>=0.6.0', 'google-generativeai'],
+      install_requires=['docassemble.ALToolbox>=0.6.0'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/GithubFeedbackForm/', package='docassemble.GithubFeedbackForm'),
      )


### PR DESCRIPTION
The dep is not compatible with DA 1.8.X due to further dependency chain conflicts. Just removing the python dependency will fix issues with those versions, while allowing the feature to still work on DA 1.7.X and below.

Does add some quick documentation about the feature on the README page, so the feature doesn't disappear into "code only" documentation.

Wasn't able to recreate the error that @ekressmiller was seeing, but was able to check that we don't override DA's version of protobuf.

In the future, could consider using optional dependencies (https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#dependencies-and-requirements) and packaging extras to still allow folks to install the gen ai dependency with `docassemble.GitHubFeedback[genai]`. This will be simpler once we transition to `pyproject.toml`, which only has good support in DA 1.8.X.

Fix #74.