### PR TITLE
Don't pre-load test file

### DIFF
--- a/docassemble/GithubFeedbackForm/test_feedback_db.py
+++ b/docassemble/GithubFeedbackForm/test_feedback_db.py
@@ -1,3 +1,5 @@
+# do not pre-load
+
 from testcontainers.postgres import PostgresContainer
 from unittest import TestCase
 from unittest.mock import patch


### PR DESCRIPTION
Without this, the following lines start appearing in the logs:

```
Import of docassemble.GithubFeedbackForm.test_feedback_db failed.  ModuleNotFoundError: No module named 'testcontainers'
```

`testcontainers` isn't a runtime dependency, only a test one (can't distinguish between the two until we get `pyproject.toml` files in all our projects), so it's not needed to be installed on docassemble. The whole file should be ignored and not loaded anyway.